### PR TITLE
PIPE2D-425: convert hexapod header keywords to match real instrument

### DIFF
--- a/python/pfs/instmodel/splinedPsf.py
+++ b/python/pfs/instmodel/splinedPsf.py
@@ -163,10 +163,10 @@ class SplinedPsf(psf.Psf):
                 return self.perFiberCoeffs[fibers]
 
     def getCards(self):
-        cards = [('HIERARCH sim.slit.xoffset', self.slitOffset[0], 'slit fiber offset, mm'),
-                 ('HIERARCH sim.slit.yoffset', self.slitOffset[1], 'slit wavelength offset, mm')]
-
-        return cards
+        return [('W_ENFCAZ', self.slitOffset[0], 'spatial slit offset, mm'),
+                ('W_ENFCAY', self.slitOffset[1], 'spectral slit offset, mm'),
+                ('W_ENFCAX', 0.0, 'focus offset, mm'),
+                ]
 
     def _focalPlaneXToDetectorX(self, x, correctToLL=False):
         """ Given focal plane positions, return detector positions.


### PR DESCRIPTION
The real instrument writes W_ENFCA[XYZ] header keywords for the
hexapod position. Since the pipeline looks for these, we should
write the same.