### PR TITLE
Added support for psfFlux, totalFlux, and photometry errors.

### DIFF
--- a/python/pfs/instmodel/lightSource.py
+++ b/python/pfs/instmodel/lightSource.py
@@ -201,6 +201,16 @@ class LightSource:
             Status of fiber.
         fiberFlux : array of `float`
             Array of fluxes in [nJy].
+        psfFlux : array of `float`
+            List of psf fluxes for each fiber [nJy].
+        totalFlux : array of `float`
+            List of total fluxes for each fiber [nJy].
+        fiberFluxErr : array of `float`
+            List of fiber flux errors for each fiber [nJy].
+        psfFluxErr : array of `float`
+            List of psf flux errors for each fiber [nJy].
+        totalFluxErr : array of `float`
+            List of total flux errors for each fiber [nJy].
         """
         index = self.pfsDesign.selectFiber(fiberId)
         assert len(index) == 1
@@ -213,10 +223,26 @@ class LightSource:
         fiberStatus = self.pfsDesign.fiberStatus[index]
         fiberFlux = dict(zip(self.pfsDesign.filterNames[index],
                          self.pfsDesign.fiberFlux[index]))
+        psfFlux = dict(zip(self.pfsDesign.filterNames[index],
+                       self.pfsDesign.psfFlux[index]))
+        totalFlux = dict(zip(self.pfsDesign.filterNames[index],
+                         self.pfsDesign.totalFlux[index]))
+        fiberFluxErr = dict(zip(self.pfsDesign.filterNames[index],
+                            self.pfsDesign.fiberFluxErr[index]))
+        psfFluxErr = dict(zip(self.pfsDesign.filterNames[index],
+                          self.pfsDesign.psfFluxErr[index]))
+        totalFluxErr = dict(zip(self.pfsDesign.filterNames[index],
+                            self.pfsDesign.totalFluxErr[index]))
         return SimpleNamespace(index=index, catId=catId, objId=objId,
                                tract=tract, patch=patch,
                                targetType=targetType, fiberStatus=fiberStatus,
-                               fiberFlux=fiberFlux)
+                               fiberFlux=fiberFlux,
+                               psfFlux=psfFlux,
+                               totalFlux=totalFlux,
+                               fiberFluxErr=fiberFluxErr,
+                               psfFluxErr=psfFluxErr,
+                               totalFluxErr=totalFluxErr
+                               )
 
     def getSkySpectrum(self):
         """Return a sky spectrum"""

--- a/python/pfs/instmodel/transmutePfsDesign.py
+++ b/python/pfs/instmodel/transmutePfsDesign.py
@@ -40,6 +40,11 @@ def shuffleFibers(design):
     design.targetType = design.targetType[indices]
     design.fiberStatus = design.fiberStatus[indices]
     design.fiberFlux = [design.fiberFlux[ii] for ii in indices]
+    design.psfFlux = [design.psfFlux[ii] for ii in indices]
+    design.totalFlux = [design.totalFlux[ii] for ii in indices]
+    design.fiberFluxErr = [design.fiberFluxErr[ii] for ii in indices]
+    design.psfFluxErr = [design.psfFluxErr[ii] for ii in indices]
+    design.totalFluxErr = [design.totalFluxErr[ii] for ii in indices]
     design.filterNames = [design.filterNames[ii] for ii in indices]
     design.pfiNominal = design.pfiNominal[indices]
 


### PR DESCRIPTION
Added following photometric attributes to psfDesign/psfConfig files:

psfFlux
totalFlux
fiberFluxError
psfFluxError
totalFluxError

Note that fiberMag has been renamed to fiberFlux as part
of DAMD-85, so not within scope of this ticket.